### PR TITLE
fix return home button

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,8 +10,8 @@
       <img style="max-width: 150px;" src="/assets/{{ site.brand_logo }}"/>
     </a>
     <p class="m-0 text-light">{{ site.content_type }}</p>
-    {% if site.nav_button %}
-    <a style="height: auto;" class="btn btn-lg btn-outline py-2 mt-4">Return to {{ site.brand_name }} Home</a>
+    {% if site.nav_button and page.title != 'Home' %}
+    <a style="height: auto;" href="{{ site.url }}{{ site.baseurl }}" class="btn btn-lg btn-outline py-2 mt-4">Return to {{ site.brand_name }} Home</a>
     {% endif %}
 
   </div>


### PR DESCRIPTION
On mobile devices, a return home button was showing up.
However, this button was not redirecting the user to the home and it was shown in the home itself.

This PR fixes its behavior in the following way:

- The button now is not shown in the home
- The button now effectively redirects the user to the home

Example in the home:
![image](https://user-images.githubusercontent.com/14928080/208667695-625b1d2f-2a25-4fcf-bd52-eb9690c3f5b1.png)

Example in the tutorials page:
![image](https://user-images.githubusercontent.com/14928080/208668272-b34542fe-3a28-4eed-b983-bf063266f5c8.png)
