### PR TITLE
Fix Colosseum OAI-RIC tutorial and add X5G Journal

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -238,6 +238,15 @@ publications:
     year: 2024
     pdflink: "https://www.researchgate.net/profile/Maria_Tsampazi/publication/380971138_PandORA_Automated_Design_and_Comprehensive_Evaluation_of_Deep_Reinforcement_Learning_Agents_for_Open_RAN/links/66577409479366623a209b1b/PandORA-Automated-Design-and-Comprehensive-Evaluation-of-Deep-Reinforcement-Learning-Agents-for-Open-RAN.pdf"
 
+  - name: villa2024x5gtmc
+    author: D. Villa, I. Khan, F. Kaltenberger, N. Hedberg, R. Soares da Silva, S. Maxenti, L. Bonati, A. Kelkar, C. Dick, E. Baena, J. M. Jornet, T. Melodia, M. Polese, and D. Koutsonikolas
+    title: "X5G: An Open, Programmable, Multi-vendor, End-to-end, Private 5G O-RAN Testbed with NVIDIA ARC and OpenAirInterface"
+    journal: "arXiv:2406.15935 [cs.NI]"
+    pages: 1-15
+    month: June
+    year: 2024
+    pdflink: "https://arxiv.org/pdf/2406.15935"
+    bibtexlink: "https://ece.northeastern.edu/wineslab/wines_bibtex/villa2024x5gtmc.txt"
 
 # these publications are NOT automatically printed in the publications page but we reference them in some of the pages
 other:

--- a/_posts/tutorials/2023-11-28-oai-o-ran-rrm-xapp.md
+++ b/_posts/tutorials/2023-11-28-oai-o-ran-rrm-xapp.md
@@ -61,7 +61,7 @@ dbaas:latest
 xapp:latest
 {% endhighlight %}
 
-Start the gNB in the `oai-gbr-ran` SRN:
+Start the gNB in the `oai-ran-gbr` SRN:
 
 {% highlight bash %}
 ./run_gnb.sh -t donor
@@ -70,10 +70,10 @@ Start the gNB in the `oai-gbr-ran` SRN:
 In the same SRN, start the `e2term`:
 
 {% highlight bash %}
-./run_e2sim.sh RIC_IP
+./run_e2sim.sh RIC_IP RIC_PORT
 {% endhighlight %}
 
-where `RIC_IP` is the `col0` IP address you have previously found. The E2 Agent of the gNB is successfully connected with the RIC if the following line is shown:
+where `RIC_IP` is the `col0` IP address you have previously found, and `RIC_PORT` is the default `36422`. The E2 Agent of the gNB is successfully connected with the RIC if the following line is shown:
 
 {% highlight bash %}
 [E2AP] Received SETUP-RESPONSE-SUCCESS
@@ -97,14 +97,16 @@ We now start the xApp. Back to the RIC container, attach a terminal to the `xApp
 docker exec -it xapp bash
 {% endhighlight %}
 
-A basic xApp and different SLA management xApp are available, please refer to the paper above for all the details. 
+# A basic xApp and different SLA management xApp are available, please refer to the paper above for all the details. 
 
-The basic monitoring xApp can be started as follows:
-{% highlight bash %}
-python3 base_xapp.py
-{% endhighlight %}
+# The basic monitoring xApp can be started as follows:
+# {% highlight bash %}
+# python3 base_xapp.py
+# {% endhighlight %}
 
-After stopping the basic xApp, we start the advanced xApp implementing an elastic SLA policy: 
+# After stopping the basic xApp, we start the advanced xApp implementing an elastic SLA policy:
+
+Different SLA management xApps are available, please refer to the paper above for all the details. We start the advanced xApp implementing an elastic SLA policy:
 {% highlight bash %}
 python3 elastic_sla.py
 {% endhighlight %}

--- a/_posts/tutorials/2024-05-18-x5g-kpm-xapp.md
+++ b/_posts/tutorials/2024-05-18-x5g-kpm-xapp.md
@@ -9,16 +9,16 @@ short-description: How to run a KPM xApp leveraging the X5G testbed comprising O
 
 {% assign publications = site.data.publications %}
 
-{% assign el = publications.other | where: "name", "villa2024x5g" %}
+{% assign el = publications.publications | where: "name", "villa2024x5gtmc" %}
 {% assign element = el[0] %}
-{% capture pub_villa2024x5g %}
+{% capture pub_villa2024x5gtmc %}
 {% include pub-template.html %}
 {% endcapture %}
 
 [X5G](https://openrangym.com/experimental-platforms/x5g) is an open, programmable, and multi-vendor private 5G O-RAN testbed that leverages the [NVIDIA Aerial](https://docs.nvidia.com/aerial/index.html) SDK for the High-PHY layer and [OpenAirInterface](https://openairinterface.org/) for the higher layers.
 
 More details can be found in the following paper:
-> {{ pub_villa2024x5g | strip_newlines }}
+> {{ pub_villa2024x5gtmc | strip_newlines }}
 > {: .text-justify}
 
 This tutorial servers as a reference on how to operate a Key Performance Measurement (KPM) xApp in an end-to-end platform with similar capabilities to those provided by X5G. A possible final outcome of this tutorial can be found on this [X5G Overview Video](https://www.youtube.com/watch?v=_bYY12wuhzk&ab_channel=MichelePolese).


### PR DESCRIPTION
As the title states, apply the following:
- Fix the tutorial for Colosseum with the new patch to make the RIC work again. The images have been updated in Colosseum, too.
- Added X5G journal references in the right spots.